### PR TITLE
Fix handling of Sync_With_Server request that failed to bind

### DIFF
--- a/src/polyorb-orb.adb
+++ b/src/polyorb-orb.adb
@@ -6,7 +6,7 @@
 --                                                                          --
 --                                 B o d y                                  --
 --                                                                          --
---         Copyright (C) 2001-2017, Free Software Foundation, Inc.          --
+--         Copyright (C) 2001-2018, Free Software Foundation, Inc.          --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -1082,6 +1082,9 @@ package body PolyORB.ORB is
                Set_Exception (Req.all, Error);
                Catch (Error);
 
+               --  If binding failed, Surrogate should be unset
+
+               pragma Assert (Req.Surrogate = null);
                Emit_No_Reply (Req.Requesting_Component,
                               Servants.Iface.Executed_Request'(Req => Req));
                return;

--- a/src/polyorb-protocols.adb
+++ b/src/polyorb-protocols.adb
@@ -6,7 +6,7 @@
 --                                                                          --
 --                                 B o d y                                  --
 --                                                                          --
---         Copyright (C) 2001-2012, Free Software Foundation, Inc.          --
+--         Copyright (C) 2001-2018, Free Software Foundation, Inc.          --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -245,15 +245,23 @@ package body PolyORB.Protocols is
                   Protocols.Iface.Flush'(Message with null record));
             end if;
 
+            --  Send a reply if one is expected (per sync scope) and the
+            --  request was completed (i.e. not aborted). Note that for
+            --  a Sync_With_Server request, the ORB normally generates an
+            --  Acknowledge_Request after the servant has been located and
+            --  prior to making the upcall, but it can also generate an
+            --  Executed_Request to return an exception in the case where
+            --  servant location failed (denoted by Surrogate = null).
+
             if not Req.Aborted
                  and then
                (Is_Set (Sync_With_Target, Req.Req_Flags)
                   or else
-                Is_Set (Sync_Call_Back,   Req.Req_Flags))
+                Is_Set (Sync_Call_Back, Req.Req_Flags)
+                  or else
+                (Is_Set (Sync_With_Server, Req.Req_Flags)
+                   and then Req.Surrogate = null))
             then
-               --  Send a reply if one is expected (per sync scope) and the
-               --  request was completed (i.e. not aborted).
-
                Send_Reply (Session_Access (Sess), Req);
             end if;
 

--- a/src/polyorb-requests.adb
+++ b/src/polyorb-requests.adb
@@ -6,7 +6,7 @@
 --                                                                          --
 --                                 B o d y                                  --
 --                                                                          --
---         Copyright (C) 2001-2017, Free Software Foundation, Inc.          --
+--         Copyright (C) 2001-2018, Free Software Foundation, Inc.          --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -135,6 +135,11 @@ package body PolyORB.Requests is
 
    procedure Destroy_Request (Req : in out Request_Access) is
    begin
+      --  As a precaution, clear Req.Surrogate so that if a dangling
+      --  pointer to Req exists, at least it won't try to access the
+      --  servant.
+
+      Req.Surrogate := null;
       Free (Req);
    end Destroy_Request;
 


### PR DESCRIPTION
For a Sync_With_Server request, a reply must be generated (and
the request must be removed from the protocol session's list of
pending requests) in all cases once all location forwarding is
completed, and the servant is identified.

Do not omit this step in the case where the binding phase failed
and no servant could be located (or the request will be destroyed
while still being pointed to by the session's pending request list).

Fixes R706-015