### PR TITLE
Complete removal of legacy SSL methods

### DIFF
--- a/src/polyorb.conf
+++ b/src/polyorb.conf
@@ -592,7 +592,7 @@ enable_fast_path=true
 
 #[my_credentials]
 #transport_credentials_type=tls
-#tls.method=tls1
+#tls.method=any
 #tls.certificate_file=my.crt
 #tls.certificate_chain_file=
 #tls.private_key_file=my.key

--- a/src/security/tls/polyorb-security-credentials-tls.adb
+++ b/src/security/tls/polyorb-security-credentials-tls.adb
@@ -6,7 +6,7 @@
 --                                                                          --
 --                                 B o d y                                  --
 --                                                                          --
---         Copyright (C) 2005-2012, Free Software Foundation, Inc.          --
+--         Copyright (C) 2005-2018, Free Software Foundation, Inc.          --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -199,11 +199,11 @@ package body PolyORB.Security.Credentials.TLS is
       elsif Method_Name = "tls1" then
          Method := TLS_1;
 
-      elsif Method_Name = "ssl3" then
-         Method := SSL_3;
+      elsif Method_Name = "tls11" then
+         Method := TLS_1_1;
 
-      elsif Method_Name = "ssl2" then
-         Method := SSL_2;
+      elsif Method_Name = "tls12" then
+         Method := TLS_1_2;
 
       else
          Throw (Error, Bad_Param_E,

--- a/src/security/tls/polyorb-tls.adb
+++ b/src/security/tls/polyorb-tls.adb
@@ -6,7 +6,7 @@
 --                                                                          --
 --                                 B o d y                                  --
 --                                                                          --
---         Copyright (C) 2005-2012, Free Software Foundation, Inc.          --
+--         Copyright (C) 2005-2018, Free Software Foundation, Inc.          --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -199,21 +199,21 @@ package body PolyORB.TLS is
 
       --  Methods
 
-      function SSLv2_method return SSL_Method;
-      function SSLv2_client_method return SSL_Method;
-      function SSLv2_server_method return SSL_Method;
-
-      function SSLv23_method return SSL_Method;
-      function SSLv23_client_method return SSL_Method;
-      function SSLv23_server_method return SSL_Method;
-
-      function SSLv3_method return SSL_Method;
-      function SSLv3_client_method return SSL_Method;
-      function SSLv3_server_method return SSL_Method;
+      function TLS_method return SSL_Method;
+      function TLS_client_method return SSL_Method;
+      function TLS_server_method return SSL_Method;
 
       function TLSv1_method return SSL_Method;
       function TLSv1_client_method return SSL_Method;
       function TLSv1_server_method return SSL_Method;
+
+      function TLSv1_1_method return SSL_Method;
+      function TLSv1_1_client_method return SSL_Method;
+      function TLSv1_1_server_method return SSL_Method;
+
+      function TLSv1_2_method return SSL_Method;
+      function TLSv1_2_client_method return SSL_Method;
+      function TLSv1_2_server_method return SSL_Method;
 
       --  Error handling
 
@@ -279,18 +279,18 @@ package body PolyORB.TLS is
       pragma Import (C, SSL_set_fd,               "SSL_set_fd");
       pragma Import (C, SSL_shutdown,             "SSL_shutdown");
       pragma Import (C, SSL_write,                "SSL_write");
-      pragma Import (C, SSLv2_client_method,      "SSLv2_client_method");
-      pragma Import (C, SSLv2_method,             "SSLv2_method");
-      pragma Import (C, SSLv2_server_method,      "SSLv2_server_method");
-      pragma Import (C, SSLv3_client_method,      "SSLv3_client_method");
-      pragma Import (C, SSLv3_method,             "SSLv3_method");
-      pragma Import (C, SSLv3_server_method,      "SSLv3_server_method");
-      pragma Import (C, SSLv23_client_method,     "SSLv23_client_method");
-      pragma Import (C, SSLv23_method,            "SSLv23_method");
-      pragma Import (C, SSLv23_server_method,     "SSLv23_server_method");
+      pragma Import (C, TLS_client_method,        "TLS_client_method");
+      pragma Import (C, TLS_method,               "TLS_method");
+      pragma Import (C, TLS_server_method,        "TLS_server_method");
       pragma Import (C, TLSv1_client_method,      "TLSv1_client_method");
       pragma Import (C, TLSv1_method,             "TLSv1_method");
       pragma Import (C, TLSv1_server_method,      "TLSv1_server_method");
+      pragma Import (C, TLSv1_1_client_method,    "TLSv1_1_client_method");
+      pragma Import (C, TLSv1_1_method,           "TLSv1_1_method");
+      pragma Import (C, TLSv1_1_server_method,    "TLSv1_1_server_method");
+      pragma Import (C, TLSv1_2_client_method,    "TLSv1_2_client_method");
+      pragma Import (C, TLSv1_2_method,           "TLSv1_2_method");
+      pragma Import (C, TLSv1_2_server_method,    "TLSv1_2_server_method");
       pragma Import (C, sk_SSL_CIPHER_num,
                      "__PolyORB_sk_SSL_CIPHER_num");
       pragma Import (C, sk_SSL_CIPHER_value,
@@ -471,24 +471,6 @@ package body PolyORB.TLS is
 
    begin
       case Method is
-         when SSL_2 =>
-            M := Thin.SSLv2_method;
-
-         when SSL_2_Client =>
-            M := Thin.SSLv2_client_method;
-
-         when SSL_2_Server =>
-            M := Thin.SSLv2_server_method;
-
-         when SSL_3 =>
-            M := Thin.SSLv3_method;
-
-         when SSL_3_Client =>
-            M := Thin.SSLv3_client_method;
-
-         when SSL_3_Server =>
-            M := Thin.SSLv3_server_method;
-
          when TLS_1 =>
             M := Thin.TLSv1_method;
 
@@ -498,14 +480,32 @@ package body PolyORB.TLS is
          when TLS_1_Server =>
             M := Thin.TLSv1_server_method;
 
+         when TLS_1_1 =>
+            M := Thin.TLSv1_1_method;
+
+         when TLS_1_1_Client =>
+            M := Thin.TLSv1_1_client_method;
+
+         when TLS_1_1_Server =>
+            M := Thin.TLSv1_1_server_method;
+
+         when TLS_1_2 =>
+            M := Thin.TLSv1_2_method;
+
+         when TLS_1_2_Client =>
+            M := Thin.TLSv1_2_client_method;
+
+         when TLS_1_2_Server =>
+            M := Thin.TLSv1_2_server_method;
+
          when Any =>
-            M := Thin.SSLv23_method;
+            M := Thin.TLS_method;
 
          when Any_Client =>
-            M := Thin.SSLv23_client_method;
+            M := Thin.TLS_client_method;
 
          when Any_Server =>
-            M := Thin.SSLv23_server_method;
+            M := Thin.TLS_server_method;
       end case;
 
       Result := Thin.SSL_CTX_new (M);

--- a/src/security/tls/polyorb-tls.ads
+++ b/src/security/tls/polyorb-tls.ads
@@ -6,7 +6,7 @@
 --                                                                          --
 --                                 S p e c                                  --
 --                                                                          --
---         Copyright (C) 2005-2012, Free Software Foundation, Inc.          --
+--         Copyright (C) 2005-2018, Free Software Foundation, Inc.          --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -40,10 +40,10 @@ with PolyORB.X509;
 package PolyORB.TLS is
 
    type TLS_Method_Type is
-     (SSL_2, SSL_2_Client, SSL_2_Server,
-      SSL_3, SSL_3_Client, SSL_3_Server,
-      TLS_1, TLS_1_Client, TLS_1_Server,
-      Any,   Any_Client,   Any_Server);
+     (TLS_1,   TLS_1_Client,   TLS_1_Server,
+      TLS_1_1, TLS_1_1_Client, TLS_1_1_Server,
+      TLS_1_2, TLS_1_2_Client, TLS_1_2_Server,
+      Any,     Any_Client,     Any_Server);
 
    type TLS_Verification_Mode_Flag is
      (Peer, Fail_If_No_Peer_Certificate, Client_Once);

--- a/src/ssl/polyorb-ssl.adb
+++ b/src/ssl/polyorb-ssl.adb
@@ -6,7 +6,7 @@
 --                                                                          --
 --                                 B o d y                                  --
 --                                                                          --
---         Copyright (C) 2005-2017, Free Software Foundation, Inc.          --
+--         Copyright (C) 2005-2018, Free Software Foundation, Inc.          --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -125,21 +125,21 @@ package body PolyORB.SSL is
 
       --  Methods
 
-      function SSLv2_method return SSL_Method;
-      function SSLv2_client_method return SSL_Method;
-      function SSLv2_server_method return SSL_Method;
-
-      function SSLv23_method return SSL_Method;
-      function SSLv23_client_method return SSL_Method;
-      function SSLv23_server_method return SSL_Method;
-
-      function SSLv3_method return SSL_Method;
-      function SSLv3_client_method return SSL_Method;
-      function SSLv3_server_method return SSL_Method;
+      function TLS_method return SSL_Method;
+      function TLS_client_method return SSL_Method;
+      function TLS_server_method return SSL_Method;
 
       function TLSv1_method return SSL_Method;
       function TLSv1_client_method return SSL_Method;
       function TLSv1_server_method return SSL_Method;
+
+      function TLSv1_1_method return SSL_Method;
+      function TLSv1_1_client_method return SSL_Method;
+      function TLSv1_1_server_method return SSL_Method;
+
+      function TLSv1_2_method return SSL_Method;
+      function TLSv1_2_client_method return SSL_Method;
+      function TLSv1_2_server_method return SSL_Method;
 
       --  Sockets subprograms
 
@@ -264,18 +264,18 @@ package body PolyORB.SSL is
       pragma Import (C, SSL_shutdown, "SSL_shutdown");
       pragma Import (C, SSL_write, "SSL_write");
 
-      pragma Import (C, SSLv2_method, "SSLv2_method");
-      pragma Import (C, SSLv2_client_method, "SSLv2_client_method");
-      pragma Import (C, SSLv2_server_method, "SSLv2_server_method");
-      pragma Import (C, SSLv23_method, "SSLv23_method");
-      pragma Import (C, SSLv23_client_method, "SSLv23_client_method");
-      pragma Import (C, SSLv23_server_method, "SSLv23_server_method");
-      pragma Import (C, SSLv3_method, "SSLv3_method");
-      pragma Import (C, SSLv3_client_method, "SSLv3_client_method");
-      pragma Import (C, SSLv3_server_method, "SSLv3_server_method");
-      pragma Import (C, TLSv1_method, "TLSv1_method");
-      pragma Import (C, TLSv1_client_method, "TLSv1_client_method");
-      pragma Import (C, TLSv1_server_method, "TLSv1_server_method");
+      pragma Import (C, TLS_method,            "TLS_method");
+      pragma Import (C, TLS_client_method,     "TLS_client_method");
+      pragma Import (C, TLS_server_method,     "TLS_server_method");
+      pragma Import (C, TLSv1_method,          "TLSv1_method");
+      pragma Import (C, TLSv1_client_method,   "TLSv1_client_method");
+      pragma Import (C, TLSv1_server_method,   "TLSv1_server_method");
+      pragma Import (C, TLSv1_1_method,        "TLSv1_1_method");
+      pragma Import (C, TLSv1_1_client_method, "TLSv1_1_client_method");
+      pragma Import (C, TLSv1_1_server_method, "TLSv1_1_server_method");
+      pragma Import (C, TLSv1_2_method,        "TLSv1_2_method");
+      pragma Import (C, TLSv1_2_client_method, "TLSv1_2_client_method");
+      pragma Import (C, TLSv1_2_server_method, "TLSv1_2_server_method");
 
       pragma Import (C, sk_SSL_CIPHER_num, "__PolyORB_sk_SSL_CIPHER_num");
       pragma Import (C, sk_SSL_CIPHER_value, "__PolyORB_sk_SSL_CIPHER_value");
@@ -447,15 +447,6 @@ package body PolyORB.SSL is
 
    begin
       case Method is
-         when SSL_3 =>
-            M := Thin.SSLv3_method;
-
-         when SSL_3_Client =>
-            M := Thin.SSLv3_client_method;
-
-         when SSL_3_Server =>
-            M := Thin.SSLv3_server_method;
-
          when TLS_1 =>
             M := Thin.TLSv1_method;
 
@@ -465,14 +456,32 @@ package body PolyORB.SSL is
          when TLS_1_Server =>
             M := Thin.TLSv1_server_method;
 
+         when TLS_1_1 =>
+            M := Thin.TLSv1_1_method;
+
+         when TLS_1_1_Client =>
+            M := Thin.TLSv1_1_client_method;
+
+         when TLS_1_1_Server =>
+            M := Thin.TLSv1_1_server_method;
+
+         when TLS_1_2 =>
+            M := Thin.TLSv1_2_method;
+
+         when TLS_1_2_Client =>
+            M := Thin.TLSv1_2_client_method;
+
+         when TLS_1_2_Server =>
+            M := Thin.TLSv1_2_server_method;
+
          when Any =>
-            M := Thin.SSLv23_method;
+            M := Thin.TLS_method;
 
          when Any_Client =>
-            M := Thin.SSLv23_client_method;
+            M := Thin.TLS_client_method;
 
          when Any_Server =>
-            M := Thin.SSLv23_server_method;
+            M := Thin.TLS_server_method;
 
       end case;
 

--- a/src/ssl/polyorb-ssl.ads
+++ b/src/ssl/polyorb-ssl.ads
@@ -6,7 +6,7 @@
 --                                                                          --
 --                                 S p e c                                  --
 --                                                                          --
---         Copyright (C) 2005-2017, Free Software Foundation, Inc.          --
+--         Copyright (C) 2005-2018, Free Software Foundation, Inc.          --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -45,9 +45,10 @@ package PolyORB.SSL is
    No_SSL_Socket : constant SSL_Socket_Type;
 
    type SSL_Method_Type is
-     (SSL_3, SSL_3_Client, SSL_3_Server,
-      TLS_1, TLS_1_Client, TLS_1_Server,
-      Any,   Any_Client,   Any_Server);
+     (TLS_1,   TLS_1_Client,   TLS_1_Server,
+      TLS_1_1, TLS_1_1_Client, TLS_1_1_Server,
+      TLS_1_2, TLS_1_2_Client, TLS_1_2_Server,
+      Any,     Any_Client,     Any_Server);
 
    type SSL_Verification_Mode_Flag is
      (Peer, Fail_If_No_Peer_Certificate, Client_Once);

--- a/src/ssl/polyorb_ssl.c
+++ b/src/ssl/polyorb_ssl.c
@@ -6,7 +6,7 @@
  *                                                                          *
  *                       C   s u p p o r t   f i l e                        *
  *                                                                          *
- *         Copyright (C) 2005-2017, Free Software Foundation, Inc.          *
+ *         Copyright (C) 2005-2018, Free Software Foundation, Inc.          *
  *                                                                          *
  * PolyORB is free software; you  can  redistribute  it and/or modify it    *
  * under terms of the  GNU General Public License as published by the  Free *
@@ -31,9 +31,9 @@
  *                                                                          *
  ****************************************************************************/
 
-/* This module provides a functional binding for two OpenSSL macros */
-
 #include <openssl/ssl.h>
+
+/* Functional binding for OpenSSL macros */
 
 int __PolyORB_sk_SSL_CIPHER_num (STACK_OF(SSL_CIPHER) *sk) {
     return sk_SSL_CIPHER_num(sk);
@@ -42,3 +42,21 @@ int __PolyORB_sk_SSL_CIPHER_num (STACK_OF(SSL_CIPHER) *sk) {
 SSL_CIPHER *__PolyORB_sk_SSL_CIPHER_value (STACK_OF(SSL_CIPHER) *sk, int i) {
     return sk_SSL_CIPHER_value(sk, i);
 }
+
+/* Compatibility shim for OpenSSL version prior to 1.1.0 */
+
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+
+const SSL_METHOD *TLS_method(void) {
+  return SSLv23_method();
+}
+
+const SSL_METHOD *TLS_client_method(void) {
+  return SSLv23_client_method();
+}
+
+const SSL_METHOD *TLS_server_method(void) {
+  return SSLv23_server_method();
+}
+
+#endif


### PR DESCRIPTION
* Remove import SSLv3 and SSLv23
* Change default from SSLv23 to TLS (with compatibility shim
  for OpenSSL prior to 1.1.0)
* Add support for TLS_1_1 and TLS_1_2

Fixes RA30-032
Completion of process initiated on QB24-032, R308-002