### PR TITLE
Add support for relocatable starter

### DIFF
--- a/compilers/gnatdist/xe_back-polyorb.adb
+++ b/compilers/gnatdist/xe_back-polyorb.adb
@@ -280,8 +280,10 @@ package body XE_Back.PolyORB is
             declare
                Partition : Partition_Type renames Partitions.Table (J);
                Full_Cmd  : constant String := Get_Name_String
-                             (Quote (To_Absolute_File
-                                       (Partition.Executable_File)
+                             (Quote ((if Relocatable_Starter
+                                      then Partition.Executable_File
+                                      else To_Absolute_File
+                                             (Partition.Executable_File))
                                      & Partition.Command_Line));
                Env : constant String := Get_Env_Vars (J, Names_Only => True);
             begin

--- a/compilers/gnatdist/xe_back.adb
+++ b/compilers/gnatdist/xe_back.adb
@@ -518,6 +518,21 @@ package body XE_Back is
          Current   : Partition_Type renames Partitions.Table (P);
 
       begin
+         --  When generating a relocatable starter, resolve partition path
+         --  relative to location of starter.
+
+         Write_Str ("_part=");
+         Get_Name_String (Current.Executable_File);
+         if Relocatable_Starter
+           and then not Is_Absolute_Path (Name_Buffer (1 .. Name_Len))
+         then
+            Write_Str  ("$(cd $(dirname $0) && pwd)/""");
+            Write_Name (Current.Executable_File);
+            Write_Str  ("""");
+         else
+            Write_Name (To_Absolute_File (Current.Executable_File));
+         end if;
+         Write_Eol;
 
          --  For the main partition, the command should be
          --    "<pn>" --boot_location "<bl>" <cline>
@@ -546,7 +561,7 @@ package body XE_Back is
          --  by the shell.
 
          Write_Char (Int_Quote);
-         Write_Name (To_Absolute_File (Current.Executable_File));
+         Write_Str  ("${_part}");
          Write_Char (Int_Quote);
 
          --  Boot_Location not currently supported with PolyORB, instead pass
@@ -968,12 +983,6 @@ package body XE_Back is
             Create_Dir (Current.Partition_Dir);
 
             if Present (Current.Executable_Dir) then
-               Get_Name_String (Current.Executable_Dir);
-               Set_Str_To_Name_Buffer
-                 (Normalize_Pathname
-                    (Name_Buffer (1 .. Name_Len),
-                     Resolve_Links => Resolve_Links));
-               Current.Executable_Dir := Name_Find;
                Create_Dir (Current.Executable_Dir);
             end if;
 

--- a/compilers/gnatdist/xe_flags.ads
+++ b/compilers/gnatdist/xe_flags.ads
@@ -51,6 +51,11 @@ package XE_Flags is
    Use_GPRBuild         : Boolean := False;
    --  Use GPRBuild instead of gnatmake
 
+   Relocatable_Starter  : Boolean := False;
+   --  Allow starter and partition binaries to be relocated,
+   --  and resolve partition path against starter location
+   --  at run time.
+
    Display_Compilation_Progress : Boolean := False;
 
    Bind_Only_Flag      : constant Unbounded_String := +"-b";

--- a/compilers/gnatdist/xe_usage.adb
+++ b/compilers/gnatdist/xe_usage.adb
@@ -68,6 +68,8 @@ begin
    Write_Eol;
    Write_Str ("  -t        Keep all temporary files");
    Write_Eol;
+   Write_Str ("  -r        Relocatable starter");
+   Write_Eol;
    Write_Str ("  --PCS=... "
               & "Select PCS variant (default: "
               & XE_Defs.Defaults.Default_PCS_Name & ")");

--- a/compilers/gnatdist/xe_utils.adb
+++ b/compilers/gnatdist/xe_utils.adb
@@ -1057,6 +1057,9 @@ package body XE_Utils is
                   Keep_Tmp_Files := True;
                   Add_Make_Switch ("-dn");
 
+               when 'r' =>
+                  Relocatable_Starter := True;
+
                when 'q' =>
                   Quiet_Mode := True;
                   --  Switch is passed to gnatmake later on

--- a/doc/Ada_Distributed_Systems_Annex_(DSA).rst
+++ b/doc/Ada_Distributed_Systems_Annex_(DSA).rst
@@ -1025,7 +1025,7 @@ user to override the default selection of distribution runtime library
 (PCS). By default `po_gnatdist` outputs a configuration
 report and the actions performed. The switch -n allows `po_gnatdist` to
 skip the first stage of recompilation of the non-distributed
-application.
+application. Switch -r requests a relocatable starter (see :ref:`Pragma_Starter`).
 
 The names of all configuration files must have the suffix
 `.cfg`. There may be several configuration files for the same
@@ -1307,12 +1307,13 @@ and assigned to the partition Main attribute.
 Pragma Starter
 ^^^^^^^^^^^^^^
 
-As a default, the main executable is a full Ada starter procedure. That
-means that it launches all the other partitions from an Ada program. The
-pragma Starter allows the user to ask for one starter or another. When
-the partition host is not statically defined (see :ref:`Partition_Attribute_Host`), the starter subprogram will ask for it interactively
-when it is executed.
+By default, the executable for a distributed application is an Ada
+starter procedure which will launch all other partitions.
+The host for each partition will be interactively obtained
+from the user at run time if not statically specified
+(see :ref:`Partition_Attribute_Host`).
 
+Pragma Starter allows an alternate starter to be requested.
 
 ::
 
@@ -1342,6 +1343,15 @@ when it is executed.
   The user may ask for a None starter. In this case, it is up to the user
   to launch the different partitions.
 
+* 
+  By default, the absolute path to each partition executable is
+  determined at build time and embedded in the starter. However,
+  if gnatdist command line switch -r is used, a relocatable starter
+  is generated. For a relocatable starter, if the Executable_Dir
+  for a partition is a relative path (or left unspecified), then
+  it will be resolved at run time relative to the location of
+  the starter. This allows the user to move the starter and
+  partition executables around after build.
 
 Pragma Remote_Shell
 ^^^^^^^^^^^^^^^^^^^

--- a/examples/dsa/json/build.sh
+++ b/examples/dsa/json/build.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-po_gnatdist -Premote_json -gnat05 echo_json
+po_gnatdist -Premote_json -gnat12 echo_json "$@"

--- a/examples/dsa/json/cli.adb
+++ b/examples/dsa/json/cli.adb
@@ -8,7 +8,7 @@ procedure Cli is
    J1 : JSON_Value := Create_Object;
    J2 : JSON_Value;
 begin
-   J1.Set_Field ("data", Create (123));
+   J1.Set_Field ("data", Create (Integer'(123)));
    Put_Line ("J1 = " & Write (J1));
 
    J2 := Unwrap (RCI.Frob (Wrap (J1)));

--- a/examples/dsa/json/echo_json.cfg
+++ b/examples/dsa/json/echo_json.cfg
@@ -8,4 +8,5 @@ configuration Echo_JSON is
    Client_Partition : partition;
    procedure Cli is in Client_Partition;
 
+   for Partition'Directory use "exec";
 end Echo_JSON;

--- a/examples/dsa/json/rci.adb
+++ b/examples/dsa/json/rci.adb
@@ -8,7 +8,7 @@ package body RCI is
       J_Output : JSON_Value := Create_Object;
    begin
       J_Output.Set_Field ("input", J_Input);
-      J_Output.Set_Field ("output",  Create (456));
+      J_Output.Set_Field ("output",  Create (Integer'(456)));
       return Wrap (J_Output);
    end Frob;
 


### PR DESCRIPTION
Allow partition location to be specified as a relative directory
and resolved at run time relative to the location of the starter.
This allows the starter and partition binaries to be moved around.

RA26-001