### PR TITLE
PolyORB: Disable new warnings

### DIFF
--- a/projects/polyorb_common.gpr
+++ b/projects/polyorb_common.gpr
@@ -71,6 +71,7 @@ project PolyORB_Common is
                               --  Enable all warnings, also enable elaboration
                               --  warnings, and treat all warnings as errors
                               --  if Warnings_Mode is set to "e".
+         "-gnatw_A",          --  Disable warnings on anonymous allocators
          "-gnatwU")           --  Disable warnings for unused entities
          & PolyORB_Config.Style_Switches;
 

--- a/projects/polyorb_src_dsa.gpr
+++ b/projects/polyorb_src_dsa.gpr
@@ -56,12 +56,14 @@ project PolyORB_src_dsa is
 
       Ada_RTL_Switches :=
         Compiler'Default_Switches ("Ada")
-          & ("-gnatg", "-gnatw" & PolyORB_Common.Warnings_Mode);
+          & ("-gnatg", "-gnatw" & PolyORB_Common.Warnings_Mode,
       --  Gnatmake compiles children of System with -gnatg (otherwise it is
       --  illegal to recompile such children). -gnatg sets the warnings mode
       --  to -gnatwe, so we need to reset it explicitly afterwards.
       --  Gprbuild does not set -gnatg automatically for children of System,
       --  so we specify it explicitly here.
+
+             "-gnatw_A"); --  Disable warnings on anonymous allocators
 
       for Switches ("s-*.adb") use Ada_RTL_Switches;
 


### PR DESCRIPTION
... about anonymous allocators. We might want to
fix this in a "better" way someday.

Fixes S325-042