### PR TITLE
Disable new warning on allocators with anonymous access type

### DIFF
--- a/compilers/iac/backend-be_corba_ada-nutils.adb
+++ b/compilers/iac/backend-be_corba_ada-nutils.adb
@@ -1751,6 +1751,13 @@ package body Backend.BE_CORBA_Ada.Nutils is
       Pkg         : Node_Id;
       Unit        : Node_Id;
 
+      function Make_Anon_Allocator_Warning_Pragma return Node_Id;
+      --  Returns a pragma to disable warnings about anonymous allocators. This
+      --  is necessary because we make liberal use of these. See for example
+      --  the To_Any function that is generated for a struct, which passes an
+      --  allocator to an access parameter. We should really switch to using
+      --  named access types.
+
       function Make_Style_Check_Pragma return Node_Id;
       --  Returns a node for a pragma deactivating style checks
 
@@ -1775,6 +1782,22 @@ package body Backend.BE_CORBA_Ada.Nutils is
                      (Make_Literal
                         (New_String_Value (Name_Find, Wide => False))));
       end Make_Style_Check_Pragma;
+
+      ----------------------------------------
+      -- Make_Anon_Allocator_Warning_Pragma --
+      ----------------------------------------
+
+      function Make_Anon_Allocator_Warning_Pragma return Node_Id is
+      begin
+         Set_Str_To_Name_Buffer ("use of an anonymous access type allocator");
+
+         return Make_Pragma
+                  (Pragma_Warnings,
+                   New_List
+                     (RE (RE_Off),
+                      Make_Literal
+                        (New_String_Value (Name_Find, Wide => False))));
+      end Make_Anon_Allocator_Warning_Pragma;
 
       ------------------------------------
       -- Make_Character_Encoding_Pragma --
@@ -1824,6 +1847,7 @@ package body Backend.BE_CORBA_Ada.Nutils is
 
       Append_To (Context_Clause (Pkg), Make_Style_Check_Pragma);
       Append_To (Context_Clause (Pkg), Make_Character_Encoding_Pragma);
+      Append_To (Context_Clause (Pkg), Make_Anon_Allocator_Warning_Pragma);
 
       --  Adding a comment header
 
@@ -1844,6 +1868,7 @@ package body Backend.BE_CORBA_Ada.Nutils is
       --  comment because some lines in the header may be very long.
 
       Append_To (Context_Clause (Pkg), Make_Style_Check_Pragma);
+      Append_To (Context_Clause (Pkg), Make_Anon_Allocator_Warning_Pragma);
 
       --  Adding a comment header. We only want to include source in the spec.
 

--- a/projects/polyorb_common.gpr
+++ b/projects/polyorb_common.gpr
@@ -71,6 +71,7 @@ project PolyORB_Common is
                               --  Enable all warnings, also enable elaboration
                               --  warnings, and treat all warnings as errors
                               --  if Warnings_Mode is set to "e".
+         "-gnatw_A",          --  Disable warnings on anonymous allocators
          "-gnatwU")           --  Disable warnings for unused entities
          & PolyORB_Config.Style_Switches;
 

--- a/projects/polyorb_src_dsa.gpr
+++ b/projects/polyorb_src_dsa.gpr
@@ -56,12 +56,15 @@ project PolyORB_src_dsa is
 
       Ada_RTL_Switches :=
         Compiler'Default_Switches ("Ada")
-          & ("-gnatg", "-gnatw" & PolyORB_Common.Warnings_Mode);
-      --  Gnatmake compiles children of System with -gnatg (otherwise it is
-      --  illegal to recompile such children). -gnatg sets the warnings mode
-      --  to -gnatwe, so we need to reset it explicitly afterwards.
-      --  Gprbuild does not set -gnatg automatically for children of System,
-      --  so we specify it explicitly here.
+          & ("-gnatg",
+             "-gnatw" & PolyORB_Common.Warnings_Mode,
+             --  Gnatmake compiles children of System with -gnatg (otherwise
+             --  it is illegal to recompile such children). -gnatg sets the
+             --  warnings mode to -gnatwe, so we need to reset it explicitly
+             --  afterwards.  Gprbuild does not set -gnatg automatically for
+             --  children of System, so we specify it explicitly here.
+
+             "-gnatw_A"); --  Disable warnings on anonymous allocators
 
       for Switches ("s-*.adb") use Ada_RTL_Switches;
 


### PR DESCRIPTION
We might want to fix this in a "better" way someday (moving to named
access types).

Fixes S325-042