### PR TITLE
Add missing dependencies

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -302,8 +302,9 @@ perfect-hash: build-gnatprfh src/soap/polyorb-http_methods.adb src/soap/polyorb-
 GNATPRFH = ${top_builddir}/compilers/gnatprfh/gnatprfh$(HOST_EXE_SUFFIX)
 GEN_HTTP_BODY = ${top_srcdir}/src/soap/gen_http_body
 
-#???.exe suffix : gnatprfh.exe?
-src/soap/polyorb-http_methods.adb: ${GEN_HTTP_BODY} ${GNATPRFH} 
+${GNATPRFH}: build-gnatprfh
+
+src/soap/polyorb-http_methods.adb: ${GEN_HTTP_BODY} ${GNATPRFH}
 
 # Note that the second gen_http_body command below overwrites perfect_hash.adb
 # with different content.
@@ -317,6 +318,7 @@ src/soap/polyorb-http_methods.adb src/soap/polyorb-http_headers.adb: ${GEN_HTTP_
 # src/giop, tools/po_catref. gen_codeset.
 
 GEN_CODESET = src/giop/tools/gen_codeset${HOST_EXE_SUFFIX}
+${GEN_CODESET}: build-gen_codeset
 
 build-gen_codeset:
 	mkdir -p src/giop/tools && cd src/giop/tools && \


### PR DESCRIPTION
Add dependencies for targets that build build tools, which
are necessary for succesful parallel build.

Fixes SB05-046